### PR TITLE
Update to Go 1.18.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.6-alpine
+FROM golang:1.18.1-alpine
 
 # Turn off cgo for a more static binary.
 # Specify cache directory so that we can run as nobody to build the binary.
@@ -12,4 +12,4 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN go install -v
+RUN go install -v -buildvcs=false

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,10 @@
 module github.com/sensiblecodeio/aws-creds
 
-go 1.16
+go 1.18
 
 require (
 	camlistore.org v0.0.0-20171230002226-a5a65f0d8b22
 	github.com/aws/aws-sdk-go v1.39.4
 )
+
+require github.com/jmespath/go-jmespath v0.4.0 // indirect


### PR DESCRIPTION
Use `-buildvcs=false` for now. This gives the same behaviour as previous
Go versions and is the simplest way to get the build working with Go 1.18.